### PR TITLE
Fixed normalization for Phansalkar's method

### DIFF
--- a/src/main/java/fiji/threshold/Auto_Local_Threshold.java
+++ b/src/main/java/fiji/threshold/Auto_Local_Threshold.java
@@ -633,6 +633,7 @@ public class Auto_Local_Threshold implements PlugIn {
 
 		Meanimp=duplicateImage(ip);
 		ContrastEnhancer ce = new ContrastEnhancer();
+		ce.setNormalize(true); // Needs to be true for correct normalization
 		ce.stretchHistogram(Meanimp, 0.0);
 		ImageConverter ic = new ImageConverter(Meanimp);
 		ic.convertToGray32();


### PR DESCRIPTION
In the current implementation of Phansalkar's method, the `ContrastEnhancer` doesn't stretch the histogram because normalization is disabled by default. Hence, the following multiplications by 1/255 (which are done to normalize the values to the [0, 1] range) will actually map the values to [0, maxValue/255].

While the computations are not completely off, the default value of the maximum standard deviation of 0.5 doesn't really make sense if the normalization is incorrect.. 